### PR TITLE
[PR] Fixes #32. In Rename feature, name validation prevents users to use the same name of a local model (from user's personal library)

### DIFF
--- a/src/rename.cpp
+++ b/src/rename.cpp
@@ -65,14 +65,22 @@ void RenameModel::checkLineEdited(const QString& str) {
       break;
 
     case dengueme::FileExists:
+      state = dengueme::FileExists;
       if (modelName == str) {
         ui->okButton->setDisabled(true);
         ui->namelineEdit->setStyleSheet("");
         ui->error_message->setText("");
       } else {
-        ui->namelineEdit->setStyleSheet("border: 1px solid red");
-        ui->error_message->setText(ICON_FA_TIMES_CIRCLE + tr("  A model with this name already exists in current project."));
-        ui->okButton->setDisabled(true);
+        if ((!QFile(path + QDir::separator() + str + ".xml").exists())) {
+          state = dengueme::ValidName;
+          ui->okButton->setDisabled(false);
+          ui->namelineEdit->setStyleSheet("");
+          ui->error_message->setText("");
+        } else {
+          ui->namelineEdit->setStyleSheet("border: 1px solid red");
+          ui->error_message->setText(ICON_FA_TIMES_CIRCLE + tr("  A model with this name already exists in current project."));
+          ui->okButton->setDisabled(true);
+        }
       }
       break;
 


### PR DESCRIPTION
[BUG] In Rename feature, name validation prevents users to use the same name of a local model (from user's personal library). 

This PR fixes the problem with the rename feature reported on #32. Now, when renaming a model, the duplicated name validation only prevents the use of a valid name if some model inside the same project already has this same name.

Closes #32