### PR TITLE
Update options to translate the language in combo box. Issue #50

### DIFF
--- a/src/dengueme.h
+++ b/src/dengueme.h
@@ -10,13 +10,7 @@
 
 #define ABS_APP_DIR QFileInfo(QCoreApplication::applicationFilePath()).absolutePath()
 
-#ifdef Q_OS_LINUX
-#define DEFAULT_MODELS_DIR (ABS_APP_DIR + "/../share/dengueme/Models/")
-#elif defined(Q_OS_MACOS)
 #define DEFAULT_MODELS_DIR (ABS_APP_DIR + "/Models/")
-#else
-#define DEFAULT_MODELS_DIR (ABS_APP_DIR + "/Models/")
-#endif
 
 class MainWindow;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,11 @@ int main(int argc, char* argv[]) {
   if (QFontDatabase::addApplicationFont(":/Resources/FontAwesome.otf") < 0)
     qWarning() << "FontAwesome cannot be loaded !";
 
+  if (dengueme::settingsFile.value("locale") != dengueme::settingsFile.value("gui_user_language")) {
+    dengueme::saveconfig("locale", dengueme::config("gui_user_language"));
+    dengueme::setconfig("locale", dengueme::config("gui_user_language"));
+  }
+
   QDir dir(QCoreApplication::applicationDirPath() + "/translations/");
   if (! dengueme::config("locale").isEmpty() && dengueme::config("locale") != "English") {
     QTranslator translator;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -16,16 +16,24 @@ Options::Options(QWidget* parent) :
   fontAwesome.setPixelSize(12);
 
   ui->warningMessageLabel->setFont(fontAwesome);
+  ui->iconWarning->setFont(fontAwesome);
+
+  ui->iconWarningRunLabel->setFont(fontAwesome);
   ui->warningRunLabel->setFont(fontAwesome);
+
   ui->errorWorksapcePath->setFont(fontAwesome);
   ui->errorTmePath->setFont(fontAwesome);
   ui->errorRPath->setFont(fontAwesome);
 
   ui->warningRunLabel->setText("");
+  ui->iconWarningRunLabel->setText("");
+
+  ui->warningMessageLabel->setText("");
+  ui->iconWarning->setText("");
+
   ui->errorWorksapcePath->setText("");
   ui->errorTmePath->setText("");
   ui->errorRPath->setText("");
-  ui->warningMessageLabel->setText("");
 
   ui->workspaceLineEdit->setText(dengueme::settingsFile.value("workspace").toString());
   ui->tmeLineEdit->setText(dengueme::settingsFile.value("terrame").toString());
@@ -54,7 +62,9 @@ Options::Options(QWidget* parent) :
 
       QString userLanguage = dengueme::config("locale") == "English" ? dengueme::config("gui_user_language") : getLanguageName(dengueme::config("gui_user_language"));
       QString warningLanguage = tr("  There is a pending update: the interface will change to ") + userLanguage +  tr(" in the next initialization.");
-      ui->warningMessageLabel->setText(ICON_FA_EXCLAMATION_TRIANGLE + warningLanguage);
+
+      ui->iconWarning->setText(ICON_FA_EXCLAMATION_TRIANGLE);
+      ui->warningMessageLabel->setText(warningLanguage);
     } else {
       if (getLanguageName(ui->languageComboBox->itemText(i)) == dengueme::settingsFile.value("gui_user_language"))
         ui->languageComboBox->setCurrentIndex(i);
@@ -81,16 +91,20 @@ Options::~Options() {
 }
 
 void Options::languageMessage() {
-  QString actualLanguage = dengueme::config("locale");
+  QString systemLanguage = dengueme::config("locale") == "English" ? dengueme::config("locale") : getLanguageName(dengueme::config("locale"));
 
-  if (actualLanguage != ui->languageComboBox->currentText()) {
-    ui->warningMessageLabel->setText(ICON_FA_EXCLAMATION_TRIANGLE + tr("  Please restart DengueME for the changes to take effect."));
+  if (systemLanguage != ui->languageComboBox->currentText()) {
+    ui->iconWarning->setText(ICON_FA_EXCLAMATION_TRIANGLE);
+    ui->warningMessageLabel->setText(tr("Please restart DengueME for the changes to take effect."));
   } else {
     QString oldWorkspacePath = dengueme::settingsFile.value("workspace").toString();
-    if (errorWorkspace == false && (oldWorkspacePath == ui->workspaceLineEdit->text()))
+    if (errorWorkspace == false && (oldWorkspacePath == ui->workspaceLineEdit->text())) {
+      ui->iconWarning->setText("");
       ui->warningMessageLabel->setText("");
-  }
+    }
 
+
+  }
 }
 
 void Options::checkCheckBox() {
@@ -122,7 +136,7 @@ void Options::browseRscript() {
 void Options::checkPath(QString path) {
   QObject* obj = sender();
 
-  QString warningMessage = tr("  You must reboot DengueME to apply the path change.");
+  QString warningMessage = tr("You must reboot DengueME to apply the path change.");
   QString errorMessage = tr("  This folder does not exist.");
   QString errorMessageInterpreter = tr("  This path is not valid.");
   QString styleSheet = "border: 1px solid red";
@@ -131,7 +145,8 @@ void Options::checkPath(QString path) {
     if (QDir(path).exists()) {
       QString oldWorkspacePath = dengueme::settingsFile.value("workspace").toString();
       if (path != oldWorkspacePath) {
-        ui->warningMessageLabel->setText(ICON_FA_TIMES_CIRCLE + tr("  You must reboot DengueME to apply the change."));
+        ui->iconWarning->setText(ICON_FA_EXCLAMATION_TRIANGLE);
+        ui->warningMessageLabel->setText(tr("You must reboot DengueME to apply the change."));
       }
 
       errorWorkspace = false;
@@ -169,8 +184,10 @@ void Options::checkPath(QString path) {
       QString oldPathTME = dengueme::settingsFile.value("terrame").toString();
       QString oldPathR = dengueme::settingsFile.value("rscript").toString();
       if ((oldPathTME != path) && (oldPathR != path)) {
-        ui->warningRunLabel->setText(ICON_FA_EXCLAMATION_TRIANGLE + warningMessage);
+        ui->iconWarningRunLabel->setText(ICON_FA_EXCLAMATION_TRIANGLE);
+        ui->warningRunLabel->setText(warningMessage);
       } else {
+        ui->iconWarningRunLabel->setText("");
         ui->warningRunLabel->setText("");
       }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1,6 +1,5 @@
 #include <QTranslator>
 #include <QFileDialog>
-#include <QDebug>
 #include "dengueme.h"
 #include "options.h"
 #include "ui_options.h"

--- a/src/options.h
+++ b/src/options.h
@@ -20,6 +20,7 @@ class Options : public QDialog {
   void browseRscript();
   void accept();
   void languageMessage();
+  QString getLanguageName(QString name);
   void checkPath(QString path);
   void checkCheckBox();
 

--- a/src/options.ui
+++ b/src/options.ui
@@ -106,7 +106,7 @@ padding: 5px 5px 5px 5px;</string>
      <item>
       <widget class="QTabWidget" name="tabWidget">
        <property name="currentIndex">
-        <number>1</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="tab">
         <attribute name="title">

--- a/src/options.ui
+++ b/src/options.ui
@@ -105,6 +105,9 @@ padding: 5px 5px 5px 5px;</string>
      </property>
      <item>
       <widget class="QTabWidget" name="tabWidget">
+       <property name="styleSheet">
+        <string notr="true"/>
+       </property>
        <property name="currentIndex">
         <number>0</number>
        </property>
@@ -213,12 +216,22 @@ padding: 5px 5px 5px 5px;</string>
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="warningMessageLabel">
+            <widget class="QLabel" name="iconWarning">
              <property name="styleSheet">
-              <string notr="true">color: red;</string>
+              <string notr="true">color: rgb(253, 128, 8);</string>
              </property>
              <property name="text">
-              <string>Warning Message</string>
+              <string>Icon</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="warningMessageLabel">
+             <property name="styleSheet">
+              <string notr="true">color: rgb(253, 128, 8);</string>
+             </property>
+             <property name="text">
+              <string>Warning MessageWorkspaceOrLanguage</string>
              </property>
             </widget>
            </item>
@@ -348,6 +361,9 @@ padding: 5px 5px 5px 5px;</string>
          </item>
          <item row="2" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
            <property name="topMargin">
             <number>0</number>
            </property>
@@ -358,12 +374,22 @@ padding: 5px 5px 5px 5px;</string>
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="warningRunLabel">
+            <widget class="QLabel" name="iconWarningRunLabel">
              <property name="styleSheet">
-              <string notr="true">color: red;</string>
+              <string notr="true">color: rgb(253, 128, 8);</string>
              </property>
              <property name="text">
-              <string>TextLabel</string>
+              <string>icon</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="warningRunLabel">
+             <property name="styleSheet">
+              <string notr="true">color: rgb(253, 128, 8);</string>
+             </property>
+             <property name="text">
+              <string>PathChangeWarning</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
This commit fixes a problem with selecting a language. 

Changes proposed in this pull request:

- Now the system has a gui_system_language and a gui_user_language.
- The combo box displaying the available languages is translating according to the system language.
- improved warning messages.
- **The Options labels and interface still need to be translated at the end of the sprint.**

Fixes #50